### PR TITLE
Inherit from master config unless specified in slave config

### DIFF
--- a/lib/active_record_slave/active_record_slave.rb
+++ b/lib/active_record_slave/active_record_slave.rb
@@ -21,6 +21,11 @@ module ActiveRecordSlave
       end
     if slave_config
       ActiveRecord::Base.logger.info "ActiveRecordSlave.install! v#{ActiveRecordSlave::VERSION} Establishing connection to slave database"
+
+      # Inheirt from master config unless explicitly specified in slave config.
+      master_config = ActiveRecord::Base.configurations[environment || Rails.env].tap{ |config| config.delete( "slave" ) }
+      slave_config  = master_config.merge( slave_config )
+
       Slave.establish_connection(slave_config)
 
       # Inject a new #select method into the ActiveRecord Database adapter


### PR DESCRIPTION
Fixes #13.

Typically with slave databases, most of the settings are actually the exact same as the master, except for `host` (usually).

So this allows you to write:

```yml
production:
  database: production
  username: username
  password: password
  encoding: utf8
  adapter:  mysql
  host:     master1
  pool:     50
  slave:
    host: slave1
```

Instead of:

```yml
production:
  database: production
  username: username
  password: password
  encoding: utf8
  adapter:  mysql
  host:     master1
  pool:     50
  slave:
    database: production
    username: username
    password: password
    encoding: utf8
    adapter:  mysql
    host:     slave1
    pool:     50
```

Which I think everyone can agree is much more DRY.

Of course, if the user wants to change any values or specify a completely different setup, all they are required to do is specify them in the `slave` configuration and they will be used instead of master.

But, for the vast majority of us, this makes the `slave` configuration insanely clean, easy and beautiful.