### PR TITLE
Update delegated methods to separate positional and keyword args

### DIFF
--- a/lib/active_record_replica/extensions.rb
+++ b/lib/active_record_replica/extensions.rb
@@ -5,11 +5,11 @@ module ActiveRecordReplica
 
     [:select, :select_all, :select_one, :select_rows, :select_value, :select_values].each do |select_method|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def #{select_method}(sql, name = nil, *args)
+        def #{select_method}(sql, name = nil, *args, **kwargs)
           return super if active_record_replica_read_from_primary?
   
           ActiveRecordReplica.read_from_primary do
-            reader_connection.#{select_method}(sql, "Replica: \#{name || 'SQL'}", *args)
+            reader_connection.#{select_method}(sql, "Replica: \#{name || 'SQL'}", *args, **kwargs)
           end
         end
       RUBY


### PR DESCRIPTION
Update the select methods on the Extensions module to be compatible with Ruby 3's separation of positional and keyword arguments (https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
